### PR TITLE
添加编译和安装脚本

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ cmake-build-release/
 #website
 website/hugo
 website/resources/
+
+# cpm
+cpm_cache

--- a/BUILD.md
+++ b/BUILD.md
@@ -60,7 +60,13 @@ Memory allocator override can be turned off by passing `-DKLOGG_OVERRIDE_MALLOC`
 
 ### Building on Linux
 
-Here is how to build klogg on Ubuntu 18.04.
+You can use the provided script for an automated build by running:
+
+```Bash
+./scripts/build.sh
+```
+
+Alternatively, you can follow the manual build instructions provided below. Please make sure you have all the necessary dependencies installed on your system.
 
 Install dependencies:
 ```

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 
 project(
   klogg
-  VERSION 22.06.0
+  VERSION 22.07.0
   DESCRIPTION "klogg log viewer"
   LANGUAGES C CXX ASM
 )

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,8 @@
+## INSTALLATION
+
+You can install this by executing the following command:
+
+```bash
+./scripts/install.sh
+```
+Please ensure that you have the appropriate permissions to run this script on your system.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+SCRIPTS_DIR=$(cd $(dirname $0); pwd)
+TOP_DIR=${SCRIPTS_DIR}/..
+BUILD_DIR=${TOP_DIR}/build_root
+
+read -s -p "Enter sudo Password: " sudo_passwd
+echo # Move to a new line
+
+install_dependencies() {
+  echo $sudo_passwd| sudo -S apt -y install build-essential cmake qtbase5-dev libboost-all-dev ragel
+}
+
+build_klogg() {
+  mkdir -p BUILD_DIR
+  pushd ${BUILD_DIR}
+  cmake -DCPM_SOURCE_CACHE=../cpm_cache ..
+  cmake --build . -j
+  popd
+}
+
+extract_from_tar() {
+  pushd ${TOP_DIR}
+  tar xvf cpm_cache.tar.gz
+  popd
+}
+
+build_deb_package() {
+  echo "build deb now"
+  pushd ${BUILD_DIR}
+  cpack
+  popd
+}
+
+install_dependencies
+extract_from_tar
+build_klogg
+build_deb_package

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+SCRIPTS_DIR=$(cd $(dirname $0); pwd)
+TOP_DIR=${SCRIPTS_DIR}/..
+BUILD_DIR=${TOP_DIR}/build_root
+DEB_DIR=${BUILD_DIR}/packages
+
+# actually we get the first matched deb path
+get_deb_path() {
+  deb_paths=($(find ${DEB_DIR} -name klogg*.deb -exec realpath {} \;))
+  length=${#deb_paths[@]}
+  
+  if [[ ${length} -lt 1 ]]; then
+    echo "klogg deb not found!"
+    exit 1
+  fi
+
+  first_deb_path=${deb_paths[0]}
+  echo "${first_deb_path}"
+}
+
+install_deb() {
+  deb_path=$(get_deb_path)
+  echo "${deb_path}"
+  sudo dpkg -i ${deb_path}
+}
+
+install_deb


### PR DESCRIPTION
- 添加编译和安装脚本
执行 build.sh 自动生成 .deb 包， 运行 install.sh 自动安装 klogg deb 包， 不用再搭建Qt开发环境后源码安装。
- 更新 .gitignore 文件，忽略 cpm_cache 目录
- 更新 VERSION 为 22.7.0